### PR TITLE
Convert text address input into OSM IDs.

### DIFF
--- a/gn-api.html
+++ b/gn-api.html
@@ -20,6 +20,18 @@
       id="range"
       handle-as="json"
       last-response="{{ range }}"></iron-ajax>
+
+    <iron-ajax
+      id="getOriginOsmId"
+      url="https://api.pickpoint.io/v1/forward?key=7szZGLLUxmE-Kk3ERCK3"
+      handle-as="json"
+      on-response="handleOriginResponse"></iron-ajax>
+
+    <iron-ajax
+      id="getDestinationOsmId"
+      url="https://api.pickpoint.io/v1/forward?key=7szZGLLUxmE-Kk3ERCK3"
+      handle-as="json"
+      on-response="handleDestinationResponse"></iron-ajax>
       
   </template>
 
@@ -50,23 +62,29 @@
        * 
        * Possible values are listed in the vehicles variable
        */
-      vehicle: String,
+      vehicleIndex: {
+        type: Number,
+        notify: true
+      },
       
       /**
-       * Route/range start as OSM-ID
+       * Route/range start as OSM-ID -- currently not used
        */
-      startOsmId: Number,
+      originOsmId: Number,
       
       /**
-       * Route target as OSM-ID
+       * Route target as OSM-ID -- currently not used
        */
-      targetOsmId: Number,
+      destinationOsmId: Number,
       
       /**
        * Battery load percentage.
        * Can be any value from 100 to 0
        */
-      battery: Number,
+      battery: {
+        type: Number,
+        notify: true,
+      },
       
       /**
        * Result of the routing. Needs vehicle, startOsmId,
@@ -114,14 +132,15 @@
      * Sets the route variable
      */
     getRoute : function() {
-      var ajax = document.querySelector('#route');
+      var ajax = this.$.route;
       ajax.url = this.url +
-        "vehicles/"   + this.vehicle +
-        "/routes/"    + this.startOsmId +
-        "-"           + this.targetOsmId +
+        "vehicles/"   + this.vehicleIndex +
+        "/routes/"    + this.originOsmId +
+        "-"           + this.destinationOsmId +
         "/opt/energy" +
         "?battery="   + this.battery +
         "&algorithm=EnergyAStar";
+      console.log(ajax.url);
     },
     
     /**
@@ -133,6 +152,29 @@
         "vehicles/"   + this.vehicle +
         "/ranges/"    + this.startOsmId +
         "?battery="   + this.battery;
+    },
+
+    convertInputToOsmId: function() {
+      this.pickPointUrl = "https://api.pickpoint.io/v1/forward?key=7szZGLLUxmE-Kk3ERCK3&q=";
+      this.$.getOriginOsmId.url = this.pickPointUrl + this.origin;
+      this.$.getOriginOsmId.generateRequest();
+
+      this.$.getDestinationOsmId.url = this.pickPointUrl + this.destination;
+      this.$.getDestinationOsmId.generateRequest();
+    },
+
+    handleOriginResponse: function(event) {
+      this.originOsmId = event.detail.response[0].osm_id;
+      console.log(event.detail.response[0].osm_id);
+    },
+
+    handleDestinationResponse: function(event) {
+      this.destinationOsmId = event.detail.response[0].osm_id;
+      console.log(event.detail.response[0].osm_id);
+
+      // Wait until (hopefully) both OSM IDs come back...
+      // I know, this is terrible. Will research & implement better options (some sort of a callback).
+      window.setTimeout(this.getRoute(), 1000);
     }
   });
   </script>

--- a/gn-api.html
+++ b/gn-api.html
@@ -42,7 +42,9 @@
     
     properties: {
 
-      // Server URL
+      /**
+       * Server url
+       */
       url: {
         type: String,
         value: "http://localhost:6833/greennav/"
@@ -66,17 +68,7 @@
         type: Number,
         notify: true
       },
-      
-      /**
-       * Route/range start as OSM-ID -- currently not used
-       */
-      originOsmId: Number,
-      
-      /**
-       * Route target as OSM-ID -- currently not used
-       */
-      destinationOsmId: Number,
-      
+
       /**
        * Battery load percentage.
        * Can be any value from 100 to 0
@@ -147,34 +139,70 @@
      * Sets the range variable
      */
     getRange : function() {
-      var ajax = document.querySelector('#range');
+      var ajax = this.$.range;
       ajax.url = this.url +
-        "vehicles/"   + this.vehicle +
-        "/ranges/"    + this.startOsmId +
+        "vehicles/"   + this.vehicleIndex +
+        "/ranges/"    + this.originOsmId +
         "?battery="   + this.battery;
+      console.log(ajax.url);
     },
 
-    convertInputToOsmId: function() {
+
+    /**
+     * General API call that converts `origin` or `destination` input fields to OSM IDs
+     */
+    getDirections: function() {
+      // Initialize OSM IDs to 0.
+      this.originOsmId = 0;
+      this.destinationOsmId = 0;
+
+      // Compute the OSM ID for `origin` if the mode is route OR range.
       this.pickPointUrl = "https://api.pickpoint.io/v1/forward?key=7szZGLLUxmE-Kk3ERCK3&q=";
       this.$.getOriginOsmId.url = this.pickPointUrl + this.origin;
       this.$.getOriginOsmId.generateRequest();
 
-      this.$.getDestinationOsmId.url = this.pickPointUrl + this.destination;
-      this.$.getDestinationOsmId.generateRequest();
+      // Route mode is 0, range is 1. (Comes from the selected paper-tabs index in gn-directions-menu.)
+      // Thus, for `route` mode, we need to get the destinationOsmId as well.
+      if (this.mode === 0) {
+        this.$.getDestinationOsmId.url = this.pickPointUrl + this.destination;
+        this.$.getDestinationOsmId.generateRequest();
+      }
     },
 
+
+    /**
+     * Assigns the corresponding OSM ID to `originOsmId` and calls `getRoute()`
+     * if `destinationOsmId` has been assigned as well.
+     */
     handleOriginResponse: function(event) {
       this.originOsmId = event.detail.response[0].osm_id;
-      console.log(event.detail.response[0].osm_id);
+
+      // If the directions mode is `range`, compute it right away.
+      if (this.mode === 1) {
+        this.getRange();
+      } else {
+        // If the directions mode is `route` and originOsmId has been assigned,
+        // check if destinationOsmId has been assigned and if it has, call getRoute().
+        if (this.destinationOsmId !== 0) {
+          this.getRoute();
+        }
+      }
     },
 
+    /**
+     * Assigns the corresponding OSM ID to `destinationOsmId` and calls `getRoute()`
+     * if `originOsmId` has been assigned as well.
+     */
     handleDestinationResponse: function(event) {
       this.destinationOsmId = event.detail.response[0].osm_id;
-      console.log(event.detail.response[0].osm_id);
 
-      // Wait until (hopefully) both OSM IDs come back...
-      // I know, this is terrible. Will research & implement better options (some sort of a callback).
-      window.setTimeout(this.getRoute(), 1000);
+      // If the directions mode is `route` and destinationOsmId has been assigned,
+      // check if originOsmId has been assigned and if it has, call getRoute().
+      if (this.mode === 0) {
+        if (this.originOsmId !== 0) {
+          this.getRoute();
+        }
+      }
     }
   });
   </script>


### PR DESCRIPTION
Just an idea of an implementation to convert text input into OSM IDs.

2 problems:

1. Currently I have two ajax requests for the origin and destination values. If I reuse the same iron-ajax element for both, what would be a way to figure out what value (originOsmId or destinationOsmId) to assign the returned OSM IDs to? (i.e. the possibility of having one handleResponse function)

2. Some horrible stuff on line [177](https://github.com/Greennav/gn-api/compare/master...marksurnin:master#diff-47b0917c843e46bffd496fd10e77d0adR177). Basically, I need to wait until both OSM ID values are returned before calling getRoute() to construct the url. Normally I'd use a callback, but I'm not sure yet how to do this in Polymer. I'll read up on that tomorrow, but if anyone has any ideas, let me know!